### PR TITLE
Release 0.1.1 (hotfix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,15 +66,18 @@ jobs:
       with:
         dotnet-version: '3.1.x'
     # Download all native-* artifacts made by the "build" job.
-    - if: github.event_name == 'push'
-      uses: actions/download-artifact@v2
-      name: native-macos-10.15
-    - if: github.event_name == 'push'
-      uses: actions/download-artifact@v2
-      name: native-ubuntu-20.04
-    - if: github.event_name == 'push'
-      uses: actions/download-artifact@v2
-      name: native-windows-2019
+    - uses: actions/download-artifact@v2
+      with:
+        name: native-Linux
+        path: native
+    - uses: actions/download-artifact@v2
+      with:
+        name: native-macOS
+        path: native
+    - uses: actions/download-artifact@v2
+      with:
+        name: native-Windows
+        path: native
     - uses: actions/cache@v2
       with:
         path: ~/.nuget/packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,13 @@ jobs:
             --version-suffix="dev.$GITHUB_RUN_NUMBER+${GITHUB_SHA:0:7}" \
             -o dist
         fi
+    - name: Check if native libraries are correctly placed
+      run: |
+        set -e
+        7z l dist/*.nupkg > /tmp/nupkg-files.txt
+        grep runtimes/linux/native/librandomx.so  /tmp/nupkg-files.txt
+        grep runtimes/osx/native/librandomx.dylib /tmp/nupkg-files.txt
+        grep runtimes/win7-x64/native/randomx.dll /tmp/nupkg-files.txt
     - uses: actions/upload-artifact@v2
       with:
         name: dist

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Version 0.1.1
 
 To be released.
 
+ -  Fixed a bug where submitted NuGet packages had lacked native libraries
+    for Linux/macOS/Windows.
+
 
 Version 0.1.0
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ RandomXSharp changelog
 Version 0.1.1
 -------------
 
-To be released.
+Released on May 25, 2021.
 
  -  Fixed a bug where submitted NuGet packages had lacked native libraries
     for Linux/macOS/Windows.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 RandomXSharp changelog
 ======================
 
+Version 0.1.1
+-------------
+
+To be released.
+
+
 Version 0.1.0
 -------------
 

--- a/RandomXSharp/RandomXSharp.csproj
+++ b/RandomXSharp/RandomXSharp.csproj
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <PackageId>RandomXSharp</PackageId>
     <Title>RandomXSharp</Title>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <Summary>RandomX binding for .NET</Summary>
+    <Description>RandomX binding for .NET</Description>
     <Authors>Planetarium</Authors>
     <Company>Planetarium</Company>
     <PackageProjectUrl>https://github.com/planetarium/RandomXSharp</PackageProjectUrl>


### PR DESCRIPTION
RandomXSharp 0.1.0 was released without native libraries.  This fixes CI script so that these are properly bundled in NuGet packages.