### PR TITLE
Bump .NET 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         # CHECK: When you change the below list, you need to change
         # the "download-artifact" steps in the "pack" job.
         os: [macos-10.15, ubuntu-20.04, windows-2019]
-        framework: [netcoreapp3.1, net472]
+        framework: [net6.0, net472]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/RandomXSharp.Tests/RandomXSharp.Tests.csproj
+++ b/RandomXSharp.Tests/RandomXSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
According to [the lifecycle of .NET Core](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core), the support for .NET Core 3.1 will be ended at Dec 13, 2022.

This pull request makes the CI and tests run on .NET 6.